### PR TITLE
Add pokemon js wrapper, add service worker, cache images

### DIFF
--- a/pokeapi-js-wrapper-sw.js
+++ b/pokeapi-js-wrapper-sw.js
@@ -1,0 +1,28 @@
+const imgRe = /https:\/\/raw\.githubusercontent\.com\/PokeAPI\/sprites\/[\/-\w\d]+\/[\d\w-]+\.(?:png|svg|gif)/
+const version = 1
+
+self.addEventListener('fetch', function (event) {
+    if (event.request.url.match(imgRe)) {
+        event.respondWith(caches.match(event.request).then(function (response) {
+            if (response) {
+                return response
+            }
+            
+            return fetch(event.request).then(function (response) {
+                if (event.request.url.match(imgRe)) {
+                    caches.open("pokeapi-js-wrapper-images-" + version).then(function (cache) {
+                        // The response is opaque, if it fails cache.add() will reject it
+                        cache.add(event.request.url)
+                    })
+                }
+                return response;
+            }).catch(function (error) {
+                console.error(error)
+            })
+        }))
+    }
+})
+
+self.addEventListener('install', function(event) {
+    self.skipWaiting()
+})

--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +22,18 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>React App</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <script>
+    const P = new Pokedex.Pokedex({
+      cacheImages: true
+    });
+  </script>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +43,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>


### PR DESCRIPTION
## Changes
1. Add service worker file to root of project, from pokeapi documentation.
2. Configure pokemon-js-wrapper to enable caching of images.

## Purpose
Reduce load on api, by enabling caching of pokemon images from server. This reduces time to load images on users end, and reduces response time from api. 

Closes #24 