### PR TITLE
Pokelist flexbox fix

### DIFF
--- a/src/components/PokeCard.js
+++ b/src/components/PokeCard.js
@@ -1,4 +1,5 @@
 import React from "react";
+import getTypeColors from "../util/getTypeColor";
 
 const PokeCard = ({ name, dexNo, typeTags, sprite }) => {
   return (

--- a/src/components/PokeList.js
+++ b/src/components/PokeList.js
@@ -16,16 +16,24 @@ const PokeList = ({
   const [selectAbilityOption, setSelectAbilityOption] = useState("");
   // abilityOptions: array of sorted ability names for drop-down
   const [abilityOptions, setAbilityOptions] = useState([]);
-  // state for sorting toggle
+  // Set sort type; by default, sort by Dex number
   const [sortType, setSortType] = useState(SortTypes.DEX_NO);
-  // stores filtered Pokemon array returned by sortAndFilter()
+  // stores sorted/filtered Pokemon array returned by sortAndFilter()
   const [filteredPokemons, setFilteredPokemons] = useState([]);
-  const [userDidSort, setUserDidSort]= useState(false)
+  const [userDidSort, setUserDidSort] = useState(false);
+  // Boolean for checking if user wants reverse sorted results
+  const [reverse, setReverse] = useState(false);
 
-  const setSortTypeFlags = (sortType)=>{
-    setSortType(sortType);
+  // reverse sorting
+  const setSortTypeFlags = (newSortFlag) => {
+    if (newSortFlag === sortType) {
+      setReverse(!reverse);
+    } else {
+      setSortType(newSortFlag);
+      setReverse(false);
+    }
     setUserDidSort(true);
-  }
+  };
 
   // generate tags, check for tags and types
   let typeTags, sprite;
@@ -35,13 +43,14 @@ const PokeList = ({
       return <span key={i}>{obj["type"]["name"]} </span>;
     });
   }
-  // array of Pokemon objects sorted by keys: name, weight, height, dex no
+
+  // arrays of Pokemon objects sorted by keys: name, weight, height, dex no
   const sortByName = (pokemonList) => {
     return pokemonList.sort((a, b) => {
       const nameA = a["name"];
       const nameB = b["name"];
-      if (nameA < nameB) return -1;
-      if (nameA > nameB) return 1;
+      if (nameA < nameB) return reverse ? 1 : -1;
+      if (nameA > nameB) return reverse ? -1 : 1;
       return 0;
     });
   };
@@ -50,7 +59,7 @@ const PokeList = ({
     return pokemonList.sort((a, b) => {
       const weightA = a["weight"];
       const weightB = b["weight"];
-      return weightA - weightB;
+      return reverse ? weightB - weightA : weightA - weightB;
     });
   };
 
@@ -58,14 +67,15 @@ const PokeList = ({
     return pokemonList.sort((a, b) => {
       const heightA = a["height"];
       const heightB = b["height"];
-      return heightA - heightB;
+      return reverse ? heightB - heightA : heightA - heightB;
     });
   };
+
   const sortByDexNumber = (pokemonList) => {
     return pokemonList.sort((a, b) => {
       const id1 = a["id"];
       const id2 = b["id"];
-      return id1 - id2;
+      return reverse ? id2 - id1 : id1 - id2;
     });
   };
 
@@ -92,20 +102,12 @@ const PokeList = ({
 
   useEffect(() => {
     sortAndFilter();
-  }, [sortType]);
-
+  }, [sortType, reverse]);
 
   const generateSortedCards = (pokemonList) => {
     const sortedCards = pokemonList.map((pokeObj) => {
       const { id, name, sprites, types } = pokeObj;
-      let typeTags = types.map((obj, i) => {
-        const typeName = obj["type"]["name"];
-        return (
-          <span style={{ backgroundColor: getTypeColors[typeName] }} key={i}>
-            {obj["type"]["names"]}
-          </span>
-        );
-      });
+
       let sprite = sprites["other"]["official-artwork"]["front_default"];
       return (
         <PokeCard
@@ -114,6 +116,7 @@ const PokeList = ({
           sprite={sprite}
           typeTags={typeTags}
           key={id}
+          typeTags={typeTags}
         />
       );
     });
@@ -133,7 +136,7 @@ const PokeList = ({
             setAbilityOptions={setAbilityOptions}
             setSortType={setSortTypeFlags}
           />
-          {generateSortedCards(userDidSort ? filteredPokemons: allPokemons)}
+          {generateSortedCards(userDidSort ? filteredPokemons : allPokemons)}
         </div>
       ) : fetchedData.length < 1 ? (
         <h1>Please search pokemon.</h1>

--- a/src/components/PokeList.js
+++ b/src/components/PokeList.js
@@ -35,15 +35,6 @@ const PokeList = ({
     setUserDidSort(true);
   };
 
-  // generate tags, check for tags and types
-  let typeTags, sprite;
-  if (types && sprites) {
-    sprite = sprites["other"]["official-artwork"]["front_default"];
-    typeTags = types.map((obj, i) => {
-      return <span key={i}>{obj["type"]["name"]} </span>;
-    });
-  }
-
   // arrays of Pokemon objects sorted by keys: name, weight, height, dex no
   const sortByName = (pokemonList) => {
     return pokemonList.sort((a, b) => {
@@ -104,17 +95,30 @@ const PokeList = ({
     sortAndFilter();
   }, [sortType, reverse]);
 
+   // generate tags, check for tags and types
+  let typeTags, sprite;
+  if (types && sprites) {
+    sprite = sprites["other"]["official-artwork"]["front_default"];
+    typeTags = types.map((obj, i) => {
+      const typeName = obj["type"]["name"];
+      return <span className="type-tag" style={{ backgroundColor: getTypeColors[typeName] }} key={i}>{obj["type"]["name"]} </span>;
+    });
+  }
+
   const generateSortedCards = (pokemonList) => {
     const sortedCards = pokemonList.map((pokeObj) => {
       const { id, name, sprites, types } = pokeObj;
-
+      let typeTags=types.map((typeObj,i)=>{
+        const typeName = typeObj["type"]["name"];
+        return <span style={{ backgroundColor: getTypeColors[typeName], color: '#303030', fontSize: '22px', borderRadius: "4px", padding: "4px" }} key={i}>{typeName}</span>
+      })
       let sprite = sprites["other"]["official-artwork"]["front_default"];
+
       return (
         <PokeCard
           dexNo={id}
           name={name}
           sprite={sprite}
-          typeTags={typeTags}
           key={id}
           typeTags={typeTags}
         />
@@ -126,7 +130,7 @@ const PokeList = ({
   return (
     <div className="pokeList">
       {!userDidSearch ? (
-        <div>
+        <>
           <Filter
             selectTypeOption={selectTypeOption}
             setSelectTypeOption={setSelectTypeOption}
@@ -136,8 +140,10 @@ const PokeList = ({
             setAbilityOptions={setAbilityOptions}
             setSortType={setSortTypeFlags}
           />
-          {generateSortedCards(userDidSort ? filteredPokemons : allPokemons)}
-        </div>
+          <div className="card-container">
+            {generateSortedCards(userDidSort ? filteredPokemons : allPokemons)}
+          </div>
+        </>
       ) : fetchedData.length < 1 ? (
         <h1>Please search pokemon.</h1>
       ) : (

--- a/src/styles/pokeAppStyle.css
+++ b/src/styles/pokeAppStyle.css
@@ -21,18 +21,12 @@ nav {
   flex-direction: row;
 }
 
-li {
-}
-
 .searchBarContainer {
   background-color: white;
   height: 50px;
 }
 
-.searchBarButton {
-}
-
-.pokeList {
+.search-container {
   order: 1;
   display: flex;
   flex-direction: row;
@@ -41,6 +35,12 @@ li {
   margin: 50px 130px;
   width: auto;
   border: 2px solid white;
+}
+
+.pokeList {
+  display: flex;
+  flex-direction: column;
+  margin: 20px 50px;
 }
 
 .filterBar {
@@ -55,6 +55,15 @@ li {
 
 .filterDropDown {
   width: 200px;
+}
+
+.card-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  flex-wrap: wrap;
+  border: 3px dashed blue;
+  margin: 20px 50px;
 }
 
 .card {
@@ -81,9 +90,6 @@ li {
   height: auto;
 }
 
-.typeTag {
-  border-radius: 15px;
-  padding: 3px 5px;
-  margin: 4px;
-  color: white;
+.lite-font {
+  color: #ccc;
 }


### PR DESCRIPTION
## Changes
1. Fix CSS Flexbox for displaying all the PokeCards.
2. Some tag styling.

## Purpose
To display cards in rows, not columns.

## Approach
Use flexbox on the correct element.


Closes #29 