### PR TITLE
Pokeapp background fix

### DIFF
--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import Select from "react-select";
 import { fetchAllAbilities } from "../util/fetchPokemonData";
+import allTypes  from "../util/allTypes";
 import SortTypes from "../util/SortTypes";
 
 function Filter({
@@ -10,7 +11,7 @@ function Filter({
   setSelectAbilityOption,
   abilityOptions,
   setAbilityOptions,
-  setSortType
+  setSortType,
 }) {
   // handler for Type drop-down
   const handleTypeChange = (selectTypeOption) => {
@@ -58,81 +59,6 @@ function Filter({
     getAllAbilities();
   }, []);
 
-  // array of options for Type drop-down
-  const allTypes = [
-    {
-      value: "fire",
-      label: "Fire",
-    },
-    {
-      value: "grass",
-      label: "Grass",
-    },
-    {
-      value: "water",
-      label: "Water",
-    },
-    {
-      value: "normal",
-      label: "Normal",
-    },
-    {
-      value: "dark",
-      label: "Dark",
-    },
-    {
-      value: "electric",
-      label: "Electric",
-    },
-    {
-      value: "ice",
-      label: "Ice",
-    },
-    {
-      value: "psychic",
-      label: "Psychic",
-    },
-    {
-      value: "ground",
-      label: "Ground",
-    },
-    {
-      value: "rock",
-      label: "Rock",
-    },
-    {
-      value: "bug",
-      label: "Bug",
-    },
-    {
-      value: "fighting",
-      label: "Fighting",
-    },
-    {
-      value: "poison",
-      label: "Poison",
-    },
-    {
-      value: "ghost",
-      label: "Ghost",
-    },
-    {
-      value: "fairy",
-      label: "Fairy",
-    },
-    {
-      value: "dragon",
-      label: "Dragon",
-    },
-    {
-      value: "steel",
-      label: "Steel",
-    },
-    {
-      value: "flying",
-      label: "Flying",
-    },
-  ];
   return (
     <div className="filterBar">
       <div>
@@ -149,10 +75,10 @@ function Filter({
         onChange={handleAbilityChange}
         options={abilityOptions}
       />
-      <button onClick={()=>setSortType(SortTypes.ABC)}>A-Z</button>
-      <button onClick={()=>setSortType(SortTypes.HEIGHT)}>Height</button>
-      <button onClick={()=>setSortType(SortTypes.WEIGHT)}>Weight</button>
-      <button onClick={()=>setSortType(SortTypes.DEX_NO)}>Dex No.</button>
+      <button onClick={() => setSortType(SortTypes.ABC)}>A-Z</button>
+      <button onClick={() => setSortType(SortTypes.HEIGHT)}>Height</button>
+      <button onClick={() => setSortType(SortTypes.WEIGHT)}>Weight</button>
+      <button onClick={() => setSortType(SortTypes.DEX_NO)}>Dex No.</button>
     </div>
   );
 }

--- a/src/styles/pokeAppStyle.css
+++ b/src/styles/pokeAppStyle.css
@@ -9,10 +9,10 @@ body {
   margin: 0;
   width: 100%;
   height: 100%;
+  background-color: #a29bcb;
 }
 
 .pokeApp {
-  background-color: #a29bcb;
   margin: 0 auto;
   border: 2px solid green;
   display: flex;

--- a/src/util/allTypes.js
+++ b/src/util/allTypes.js
@@ -1,0 +1,77 @@
+ // array of options for Type drop-down
+  const allTypes = [
+    {
+      value: "fire",
+      label: "Fire",
+    },
+    {
+      value: "grass",
+      label: "Grass",
+    },
+    {
+      value: "water",
+      label: "Water",
+    },
+    {
+      value: "normal",
+      label: "Normal",
+    },
+    {
+      value: "dark",
+      label: "Dark",
+    },
+    {
+      value: "electric",
+      label: "Electric",
+    },
+    {
+      value: "ice",
+      label: "Ice",
+    },
+    {
+      value: "psychic",
+      label: "Psychic",
+    },
+    {
+      value: "ground",
+      label: "Ground",
+    },
+    {
+      value: "rock",
+      label: "Rock",
+    },
+    {
+      value: "bug",
+      label: "Bug",
+    },
+    {
+      value: "fighting",
+      label: "Fighting",
+    },
+    {
+      value: "poison",
+      label: "Poison",
+    },
+    {
+      value: "ghost",
+      label: "Ghost",
+    },
+    {
+      value: "fairy",
+      label: "Fairy",
+    },
+    {
+      value: "dragon",
+      label: "Dragon",
+    },
+    {
+      value: "steel",
+      label: "Steel",
+    },
+    {
+      value: "flying",
+      label: "Flying",
+    },
+  ];
+
+  export default allTypes;


### PR DESCRIPTION
## Changes
1. Move `background-color` from `.pokeApp` block to `body` block in CSS file.

## Purpose
Have purple background cover whole page, not just til bottom of PokeList.

## Approach
Background now covers whole html, instead of just app.

Closes #41 