### PR TITLE
Get Pokemon moveset

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -15,6 +15,7 @@ export const Modal = ({
   getPokemonModalAboutContent,
   height,
   weight,
+  moveSet,
   abilities,
 }) => {
   const [cryUrlIsValid, setCryUrlIsValid] = useState(true);
@@ -69,6 +70,7 @@ export const Modal = ({
             height={height}
             weight={weight}
             abilities={abilities}
+            moveSet={moveSet}
           />
         </div>
       </div>

--- a/src/components/Moves.js
+++ b/src/components/Moves.js
@@ -1,14 +1,7 @@
 import React from "react";
 
 const Moves = ({ moveSet }) => {
-  // map over moveSet [{}]
-  const moveStyles = {
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      flexWrap: 'wrap'
-  }
-
+  // function for finding English flavor text; returns a string
   const getEngFlavorText = (texts) => {
     for (let i = 0; i < texts.length; i += 1) {
       const textObj = texts[i];
@@ -31,7 +24,7 @@ const Moves = ({ moveSet }) => {
       </ul>
     );
   });
-  return <div className="moves-panel" style={moveStyles}>{moveInfo}</div>;
+  return <div className="moves-panel">{moveInfo}</div>;
 };
 
 export default Moves;

--- a/src/components/Moves.js
+++ b/src/components/Moves.js
@@ -1,0 +1,37 @@
+import React from "react";
+
+const Moves = ({ moveSet }) => {
+  // map over moveSet [{}]
+  const moveStyles = {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      flexWrap: 'wrap'
+  }
+
+  const getEngFlavorText = (texts) => {
+    for (let i = 0; i < texts.length; i += 1) {
+      const textObj = texts[i];
+      if (textObj.language.name === "en") {
+        return textObj.flavor_text;
+      }
+    }
+  };
+
+  const moveInfo = moveSet.map((moveObj) => {
+    const { accuracy, name, power, pp, flavor_text_entries } = moveObj;
+    // call function to loop through flavor_text_entries and find "en"
+    return (
+      <ul>
+        <li>{name.toUpperCase()}</li>
+         <li>{getEngFlavorText(flavor_text_entries)}</li>
+        <li>Accuracy: {accuracy}</li>
+        <li>Power: {power}</li>
+        <li>PP: {pp}</li>
+      </ul>
+    );
+  });
+  return <div className="moves-panel" style={moveStyles}>{moveInfo}</div>;
+};
+
+export default Moves;

--- a/src/components/PokeApp.js
+++ b/src/components/PokeApp.js
@@ -15,6 +15,7 @@ function PokeApp() {
   const [allPokemons, setAllPokemon] = useState([]);
   const [userDidSearch, setUserDidSearch] = useState(false);
   const [modalData, setModalData] = useState([]);
+  const [movesData, setMovesData] = useState({});
 
   const handleNameSearch = (e) => {
     const searchBarValue = e.target.value;
@@ -39,7 +40,7 @@ function PokeApp() {
   const getAllPokemon = async (pokeUrls) => {
     try {
       const data = await fetchAllPokemons();
-      // need data["next"] & data["previous"]
+      // need data["next"] & data["previous"] for pagination
       // loop over results and fetch
       const pokemonObjs = data["results"].map((obj) => {
         const name = obj["name"];

--- a/src/components/PokeCard.js
+++ b/src/components/PokeCard.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Modal as CustomModal } from "./Modal";
 import Modal from "react-modal";
+import { fetchPokemon, fetchMove } from "../util/fetchPokemonData";
 
 const PokeCard = ({
   name,
@@ -14,10 +15,35 @@ const PokeCard = ({
   abilities,
 }) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [moveSet, setMoveSet] = useState([]);
 
   Modal.setAppElement("#root");
 
+  // get modal moveset
+  const getMoveset = async (movesArray, n) => {
+    const nMoves = [];
+    for (let i = 0; i < n; i += 1) {
+      const moveUrl = movesArray[i].move.url;
+      try {
+        const moveData = await fetchMove(moveUrl);
+        if (moveData) nMoves.push(moveData);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    return nMoves;
+  };
+
+  const getMovesByPokemon = async (id) => {
+    const pokemon = await fetchPokemon(id);
+    const moves = pokemon.moves;
+    const someMoves = await getMoveset(moves, 4);
+    setMoveSet(someMoves);
+  };
+
+  // get modal content: pokemon species info and moveset
   const triggerModalData = () => {
+    getMovesByPokemon(dexNo);
     getPokemonModalAboutContent(dexNo);
   };
 
@@ -25,14 +51,17 @@ const PokeCard = ({
     // pokemon modal content
     triggerModalData();
   }, []);
-  // console.log(`modalData in PokeCard`, modalData);
+
   return (
     <div className="card">
       <ul>
         <li>
           <img src={sprite} alt={`${name} sprite`} className="sprite" />
         </li>
-        <li className="card-name"><span>{name.toUpperCase()}</span><span> #{dexNo}</span></li>
+        <li className="card-name">
+          <span>{name.toUpperCase()}</span>
+          <span> #{dexNo}</span>
+        </li>
         <li>{typeTags}</li>
         <li>
           <button
@@ -47,6 +76,7 @@ const PokeCard = ({
       <Modal
         className="modalWindow"
         isOpen={modalIsOpen}
+        moveSet={moveSet}
         onRequestClose={() => {
           return setModalIsOpen(false);
         }}>
@@ -61,6 +91,7 @@ const PokeCard = ({
           height={height}
           weight={weight}
           abilities={abilities}
+          moveSet={moveSet}
         />
       </Modal>
     </div>

--- a/src/components/TabBar.js
+++ b/src/components/TabBar.js
@@ -4,6 +4,7 @@ import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
+import Moves from "./Moves";
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -37,14 +38,13 @@ function a11yProps(index) {
   };
 }
 
-export default function BasicTabs({ modalData, height, weight, abilities }) {
+export default function BasicTabs({ modalData, height, weight, abilities, moveSet }) {
   const [value, setValue] = React.useState(0);
   const [isAboutTextEnglish, setIsAboutTextEnglish] = React.useState(true);
   const [englishAboutTextIndex, setEnglishAboutTextIndex] = React.useState(0);
   const [isSpeciesTextEnglish, setIsSpeciesTextEnglish] = React.useState(true);
   const [englishSpeciesTextIndex, setEnglishSpeciesTextIndex] =
     React.useState(0);
-
   // create function that updates setAboutTextIsEnglish state to true
   const findEnglishText = (pathName) => {
     let found = false;
@@ -156,7 +156,7 @@ export default function BasicTabs({ modalData, height, weight, abilities }) {
 
         {/****** MOVES TAB ******/}
         <TabPanel value={value} index={3}>
-          Item Four
+          <Moves moveSet={moveSet}/>
         </TabPanel>
       </div>
     </Box>

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -88,7 +88,7 @@ $md-bg: #f9cf30;
   border: 1px solid red;
 }
 
-/* speaker button */
+// speaker button
 .nameContainer button {
   background: transparent;
   border: none;
@@ -106,3 +106,15 @@ $md-bg: #f9cf30;
   text-transform: uppercase;
 }
 
+// moves panel
+.moves-panel {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.moves-panel ul {
+  list-style: none;
+  line-height: 2;
+}

--- a/src/util/fetchPokemonData.js
+++ b/src/util/fetchPokemonData.js
@@ -2,6 +2,7 @@ const baseUrl = `https://pokeapi.co/api/v2/pokemon/`;
 const abiliUrl = `https://pokeapi.co/api/v2/ability/?offset=0&limit=327`;
 const speciesUrl = `https://pokeapi.co/api/v2/pokemon-species/`;
 
+
 // the following function can accept either pokemon name or Id and search individual pokemon
 export const fetchPokemon = async (nameOrId) => {
   try {
@@ -45,3 +46,18 @@ export const fetchAllAbilities = async () => {
     console.error(error);
   }
 };
+
+// pokemon/:id endpoint provides "moves" array(of objects, with key: "move" { "name", "url" })
+export const fetchMove = async (moveUrl)=> {
+
+  try {
+    return await fetch(moveUrl)
+      .then((response) => response.json())
+      .then((data) => data);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+
+


### PR DESCRIPTION
## Changes
1. Defined `fetchMove` in util.
2. Defined `getMoveset` in PokeCard that takes in `moves` array and `moves count` to get `n` number of moves and returns array of moves of `n` length.
3. Defined `getMovesByPokemon` in PokeCard to get Pokemon by id(Dex No.) to access `moves`.
4. Create state hook to store pokemon's `moveSet`.

## Purpose
Fetch and display 4 moves in Moves tab of modal.

## Approach
Fetch to `pokemon/:id` end point with `getMovesByPokemon` to get access to `moves` array, and call `getMoveset` to loop over moves to get 4 moves. Then store 4 moves into state and pass it down to Moves from PokeCard.

Closes #59 