### PR TITLE
Click Card to open modal.

### DIFF
--- a/public/pokeapi-js-wrapper-sw.js
+++ b/public/pokeapi-js-wrapper-sw.js
@@ -1,0 +1,28 @@
+const imgRe = /https:\/\/raw\.githubusercontent\.com\/PokeAPI\/sprites\/[\/-\w\d]+\/[\d\w-]+\.(?:png|svg|gif)/
+const version = 1
+
+self.addEventListener('fetch', function (event) {
+    if (event.request.url.match(imgRe)) {
+        event.respondWith(caches.match(event.request).then(function (response) {
+            if (response) {
+                return response
+            }
+            
+            return fetch(event.request).then(function (response) {
+                if (event.request.url.match(imgRe)) {
+                    caches.open("pokeapi-js-wrapper-images-" + version).then(function (cache) {
+                        // The response is opaque, if it fails cache.add() will reject it
+                        cache.add(event.request.url)
+                    })
+                }
+                return response;
+            }).catch(function (error) {
+                console.error(error)
+            })
+        }))
+    }
+})
+
+self.addEventListener('install', function(event) {
+    self.skipWaiting()
+})

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -49,6 +49,7 @@ export const Modal = ({
           </div>
 
           <div className="modalCloseButton">
+          {/* close button */}
             <button
               onClick={() => {
                 setIsOpen(false);

--- a/src/components/PokeCard.js
+++ b/src/components/PokeCard.js
@@ -56,7 +56,10 @@ const PokeCard = ({
   }, []);
 
   return (
-    <div className="card">
+    <>
+    <div className="card"  onClick={() => {
+              setModalIsOpen(true);
+            }}>
       <ul>
         <li>
           <img src={sprite} alt={`${name} sprite`} className="sprite" />
@@ -66,22 +69,15 @@ const PokeCard = ({
           <span> #{dexNo}</span>
         </li>
         <li>{typeTags}</li>
-        <li>
-          <button
-            onClick={() => {
-              setModalIsOpen(true);
-              triggerModalData();
-            }}>
-            Open
-          </button>
-        </li>
       </ul>
-      <Modal
+    </div>
+    <Modal
+        onAfterOpen={triggerModalData}
         className="modalWindow"
         isOpen={modalIsOpen}
         moveSet={moveSet}
         onRequestClose={() => {
-          return setModalIsOpen(false);
+          setModalIsOpen(false);
         }}>
         <CustomModal
           setIsOpen={setModalIsOpen}
@@ -99,8 +95,10 @@ const PokeCard = ({
           moveSet={moveSet}
         />
       </Modal>
-    </div>
+      </>
   );
 };
 
 export default PokeCard;
+
+

--- a/src/components/PokemonDetails.js
+++ b/src/components/PokemonDetails.js
@@ -10,6 +10,9 @@ const PokemonDetails = ({
   weight,
   abilities,
 }) => {
+
+
+
   return (
     <div>
       <div className="aboutLeftContainer">

--- a/src/components/TabBar.js
+++ b/src/components/TabBar.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import PropTypes from "prop-types";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import Typography from "@material-ui/core/Typography";
@@ -26,6 +27,12 @@ function TabPanel(props) {
     </div>
   );
 }
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.number.isRequired,
+  value: PropTypes.number.isRequired,
+};
 
 function a11yProps(index) {
   return {
@@ -86,7 +93,6 @@ export default function BasicTabs({
   };
 
   React.useEffect(() => {
-    // checkAboutTextLanguage();
     findEnglishText("flavor_text_entries");
     findEnglishText("genera");
     // eslint-disable-next-line

--- a/src/components/TabBar.js
+++ b/src/components/TabBar.js
@@ -1,7 +1,6 @@
 import * as React from "react";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
-import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import BaseStats from "./BaseStats";
 import EvolutionTab from "./EvolutionTab";

--- a/src/components/TabBar.js
+++ b/src/components/TabBar.js
@@ -1,5 +1,4 @@
 import * as React from "react";
-import PropTypes from "prop-types";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import Typography from "@material-ui/core/Typography";
@@ -19,20 +18,10 @@ function TabPanel(props) {
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
       {...other}>
-      {value === index && (
-        <Box sx={{ div: 3 }}>
-          <Typography>{children}</Typography>
-        </Box>
-      )}
+      {value === index && <Box>{children}</Box>}
     </div>
   );
 }
-
-TabPanel.propTypes = {
-  children: PropTypes.node,
-  index: PropTypes.number.isRequired,
-  value: PropTypes.number.isRequired,
-};
 
 function a11yProps(index) {
   return {
@@ -55,8 +44,9 @@ export default function BasicTabs({
   const [isAboutTextEnglish, setIsAboutTextEnglish] = React.useState(true);
   const [englishAboutTextIndex, setEnglishAboutTextIndex] = React.useState(0);
   const [isSpeciesTextEnglish, setIsSpeciesTextEnglish] = React.useState(true);
-  const [englishSpeciesTextIndex, setEnglishSpeciesTextIndex] =
-    React.useState(0);
+  const [englishSpeciesTextIndex, setEnglishSpeciesTextIndex] = React.useState(
+    0
+  );
   // create function that updates setAboutTextIsEnglish state to true
   const findEnglishText = (pathName) => {
     let found = false;
@@ -119,7 +109,8 @@ export default function BasicTabs({
       <div className="modalTabContent">
         {/****** ABOUT TAB ******/}
         <TabPanel value={value} index={0}>
-          <PokemonDetails isAboutTextEnglish={isAboutTextEnglish}
+          <PokemonDetails
+            isAboutTextEnglish={isAboutTextEnglish}
             modalData={modalData}
             englishAboutTextIndex={englishAboutTextIndex}
             englishSpeciesTextIndex={englishSpeciesTextIndex}


### PR DESCRIPTION
## Changes
1. Removed Typography component  and `open` button in PokeCard.
2. Move open modal function to PokeCard div.
3. Made Modal and PokeCard div siblings.
4. Add `onAfterOpen` prop to Modal component.

## Purpose
Allow user to open modal by clicking card instead of open button.

## Testing Steps
Click on card to open modal, and click 'x' button or outside of modal to close modal.

Closes #53 