### PR TITLE
Modal About Tab Styling

### DIFF
--- a/src/components/EvolutionTab.js
+++ b/src/components/EvolutionTab.js
@@ -7,7 +7,6 @@ const EvolutionTab = ({ evolutionChainUrl }) => {
   const [evolutionNameStrings, setEvolutionNameStrings] = useState([]);
   const [spriteUrls, setSpriteUrls] = useState([]);
 
-
   // Function to fetch chain object, save to state hook
   const fetchChain = async () => {
     try {
@@ -106,8 +105,13 @@ const EvolutionTab = ({ evolutionChainUrl }) => {
   ));
 
   const evolutionImg = () => {
-    return (<img className="evolutionImg" src={evolutionArrowImg}></img>)
-  }
+    return (
+      <img
+        className="evolutionImg"
+        src={evolutionArrowImg}
+        alt="next evolution arrow"></img>
+    );
+  };
 
   // return spritesList with evolution arrows added in between each image
   const spritesWithEvolutionArrows = () => {
@@ -121,7 +125,7 @@ const EvolutionTab = ({ evolutionChainUrl }) => {
       }
     }
     return organizedArray;
-  }
+  };
 
   return <div className="spriteContainer">{spritesWithEvolutionArrows()}</div>;
 };

--- a/src/components/PokemonDetails.js
+++ b/src/components/PokemonDetails.js
@@ -10,11 +10,8 @@ const PokemonDetails = ({
   weight,
   abilities,
 }) => {
-
-
-
   return (
-    <div>
+    <div className="aboutWrapper">
       <div className="aboutLeftContainer">
         {isAboutTextEnglish
           ? modalData["flavor_text_entries"][englishAboutTextIndex][
@@ -24,29 +21,22 @@ const PokemonDetails = ({
       </div>
 
       <div className="aboutRightContainer">
-        <div className="speciesRowContainer">
+        <div className="categoryContainer">
           <p className="aboutSpecsLabel">Species</p>
-          <p className="speciesValue">
+          <p className="aboutSpecsLabel">Height</p>
+          <p className="aboutSpecsLabel">Weight</p>
+          <p className="aboutSpecsLabel">Abilities</p>
+        </div>
+        <div className="valueContainer">
+          <p className="aboutTabValue">
             {isSpeciesTextEnglish
               ? modalData["genera"][englishSpeciesTextIndex]["genus"]
               : "Information not found"}
           </p>
-        </div>
-
-        <div className="heightRowContainer">
-          <p className="aboutSpecsLabel">Height</p>
-          <p className="heightValue">{height}</p>
-        </div>
-
-        <div className="weightRowContainer">
-          <p className="aboutSpecsLabel">Weight</p>
-          <p className="weightValue">{weight}</p>
-        </div>
-
-        <div className="abilitiesRowContainer">
-          <p className="aboutSpecsLabel">Abilities</p>
-          <p className="abilitiesValue">
-            {abilities.map((index) => index["ability"].name + " ")}
+          <p className="aboutTabValue">{height}</p>
+          <p className="aboutTabValue">{weight}</p>
+          <p className="aboutTabValue">
+            {abilities.map((index) => index["ability"].name).join(", ")}
           </p>
         </div>
       </div>

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -68,3 +68,21 @@ $type-tag-color: #303030;
   letter-spacing: 1.5px;
   font-family: $rubik;
 }
+
+//modal about tab
+.aboutLeftContainer {
+  font-family: $raleway;
+  line-height: 27px;
+  font-size: $reg;
+}
+
+.aboutSpecsLabel {
+  font-weight: 700;
+  font-family: $raleway;
+  letter-spacing: 0.7px;
+}
+
+.aboutTabValue {
+  font-family: $raleway;
+  text-transform: capitalize;
+}

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -150,3 +150,40 @@ $md-bg: #f9cf30;
   height: 100%;
   margin: 25px auto 0 auto;
 }
+
+// about tab
+.aboutWrapper {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  height: 200px;
+  margin-top: 25px;
+}
+
+.aboutLeftContainer {
+  width: 33%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.aboutRightContainer {
+  display: flex;
+  height: 150px;
+}
+
+.categoryContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.valueContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.aboutSpecsLabel {
+  margin-right: 15px;
+}


### PR DESCRIPTION
## Changes
1. Restructured content layout
2. Styled about tab in modal
3. Added missing alt tag

## Purpose
To provide a better user experience with a more formatted and styled layout to display pokemon about content.

Closes #80 