### PR TITLE
Add error handling for modal

### DIFF
--- a/src/components/EvolutionTab.js
+++ b/src/components/EvolutionTab.js
@@ -64,15 +64,24 @@ const EvolutionTab = ({ evolutionChainUrl, pokemonColor }) => {
     try {
       // array of Promises
       const urlList = evolutionNameStrings.map(async (string) => {
-        const data = await fetchPokemon(string);
-        const { name } = data;
 
-        const url = data["sprites"]["other"]["official-artwork"].front_default;
-        return {
-          name,
-          url,
-        };
-      });
+        const data = await fetchPokemon(string);
+        if(data) {
+          const { name } = data;
+
+          const url = data["sprites"]["other"]["official-artwork"].front_default;
+          return {
+            name,
+            url,
+          };
+        } else {
+          return {
+            name: 'Unavailable ',
+            url: ''
+          }
+        }
+
+      }); // end evolutionNameStrings map
 
       Promise.all(urlList).then((data) => {
         setSpriteUrls(data);

--- a/src/components/PokeCard.js
+++ b/src/components/PokeCard.js
@@ -44,16 +44,23 @@ const PokeCard = ({
   // get modal content: pokemon species info and moveset
   const triggerModalData = async () => {
     const modalContent = await getPokemonModalAboutContent(dexNo);
-    const { flavor_text_entries, genera } = modalContent;
-    const generaText = findDescriptionByLanguage(genera, "genus", "en");
-    const description = findDescriptionByLanguage(
-      flavor_text_entries,
-      "flavor_text",
-      "en"
-    );
-    setGeneraString(generaText);
-    setFlavorText(description);
-    setModalData(modalContent);
+    // check for undefined modalContent
+    if(modalContent){
+        const { flavor_text_entries, genera } = modalContent;
+        const generaText = findDescriptionByLanguage(genera, "genus", "en");
+        const description = findDescriptionByLanguage(
+          flavor_text_entries,
+          "flavor_text",
+          "en"
+        );
+        setGeneraString(generaText);
+        setFlavorText(description);
+        setModalData(modalContent);
+    } else {
+      setGeneraString('Unavailable');
+      setFlavorText('Unavailable');
+      setModalData({})
+    }
   };
 
   const prepareModal = () => {


### PR DESCRIPTION
## Changes
1. Add conditional to check for undefined data in EvolutionsTab and return 'Unavailable' for sprites, etc.
2. Add conditional to check for undefined `modalContent` in PokeCard and return 'Unavailable'. and empty object to prevent error.

## Purpose
Error handling for pokemons with more than 1 forms(ex. darmanitan-standard, darmanitan-zen, and mega evolutions).

## Approach
Return something so that error won't occur.

Closes #95 