### PR TITLE
Move searchedCard styling from main.scss to _card.scss, center card

### DIFF
--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -54,6 +54,11 @@ $card-shadow: 2px 7px 4px 0 rgba(75, 75, 75, 0.45);
   margin: 0 8px;
 }
 
+// center card that user searched on desktop and mobile
+.searchedCard {
+  margin: 0 auto;
+}
+
 // responsive cards
 @media screen and (max-width: 833px) {
   .card {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -46,10 +46,6 @@ body {
   z-index: 2;
 }
 
-.searchedCard {
-  margin-left: 23px;
-}
-
 @import "components/header";
 @import "components/filterbar";
 @import "components/card";


### PR DESCRIPTION
## Changes
1. Moved searchedCard styling to _card.scss.
2. Centered searchedCard on mobile and desktop instead of  using`margin-left`.

## Purpose
Move styling of searchedCard to _card.scss and center this card on desktop and mobile.

## Approach
Gave the card `margin: 0 auto`.

## Testing Steps
1. Start app.
2. Search Pokemon.
3.  Check on desktop and mobile screen sizes.

Closes #124 