### PR TITLE
Display names of evolutionary stages in Evolution Tab

### DIFF
--- a/src/components/EvolutionTab.js
+++ b/src/components/EvolutionTab.js
@@ -51,7 +51,7 @@ const EvolutionTab = ({ evolutionChainUrl, pokemonColor }) => {
   2. Species name is pushed into tempArray, which is then store in state as evolutionNameStrings
  */
 
-  // get name strings of evolutions and save to hook
+  // get name strings of evolutions chain and save to hook for fetching in getImgUrlFromStrings
   const getNameStrings = (namesObjArray) => {
     const nameList = namesObjArray.map((nameObj) => {
       return nameObj.species_name;
@@ -84,7 +84,7 @@ const EvolutionTab = ({ evolutionChainUrl, pokemonColor }) => {
       }); // end evolutionNameStrings map
 
       Promise.all(urlList).then((data) => {
-        setSpriteUrls(data);
+        setSpriteUrls(data); // data: array of pokemon objects
       });
     } catch (error) {
       console.error(error);
@@ -104,14 +104,15 @@ const EvolutionTab = ({ evolutionChainUrl, pokemonColor }) => {
     getImgUrlFromStrings(evolutionNameStrings);
   }, [evolutionNameStrings]);
 
-  const spritesList = spriteUrls.map((urlObj) => (
+  // map and return an array of sprites of all evolutionary stages; urlObj has pokemon name and sprite url
+  const spritesList = spriteUrls.map((urlObj) => (<div key={urlObj.name}>
     <img
       src={urlObj.url}
       alt={`${urlObj.name}sprite`}
-      key={urlObj.name}
       className="evolution-sprites"
     />
-  ));
+    <p className="evo-stage-names">{urlObj.name.toUpperCase()}</p>
+  </div>));
 
   const evolutionImg = (index) => {
     return (

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -121,6 +121,11 @@ a {
   font-weight: 900 !important;
 }
 
+// evolutions tab
+.evo-stage-names {
+  font-weight: 600;
+}
+
 // responsive typography
 @media screen and (max-width: 650px) {
   .nav-link {

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -407,6 +407,11 @@ $modal-padding: 25px;
   }
 }
 
+  // position sprite/pokemon name in evolutions tab
+.evo-stage-names {
+  text-align: center;
+}
+
 // iphone screen width
 @media screen and (max-width: 375px) {
   .backgroundModalWrapper {


### PR DESCRIPTION
## Changes
1. When mapping over `spriteUrls`, return div with `key` and then add `p` tag under sprite to display Pokemon name.
2. Give `p` tag a class and centered it in `_modal` scss.

## Purpose
Display names in Evolution tab, not just sprites.

## Approach
Create p tag and refactor the `spriteUrls.map()` to return `div` containing `img`(sprite) and `p` tags for each item in array.



## Testing Steps
1. Start app.
2. Open a modal.
3. Go to Evolution tab and check.

Closes #126 