### PR TITLE
Fix offset to not omit pokemon

### DIFF
--- a/src/components/PokeApp.js
+++ b/src/components/PokeApp.js
@@ -53,7 +53,7 @@ const PokeApp = () => {
         .then(setIsLoading(false));
 
       setQueryParams({
-        offset: queryParams.offset + 21,
+        offset: queryParams.offset + 20,
         limit: queryParams.limit,
       });
     } catch (error) {


### PR DESCRIPTION
## Changes
1. Fixed offset.

## Purpose
Originally, offset was incorrect, so some pokemons weren't fetched.

## Approach
Adjust offset in PokeApp.

## Testing Steps
Scroll down to at least pokemons no.37-39 to see if there are any duplicates or missing pokemons.



Closes #149 