### PR TITLE
Increase timeout, and call setIsLoading in catch

### DIFF
--- a/src/components/PokeApp.js
+++ b/src/components/PokeApp.js
@@ -57,6 +57,7 @@ const PokeApp = () => {
         limit: queryParams.limit,
       });
     } catch (error) {
+      setIsLoading(false);
       console.error(error);
     }
   };

--- a/src/util/fetchPokemonData.js
+++ b/src/util/fetchPokemonData.js
@@ -3,14 +3,13 @@ const Pokedex = require("pokeapi-js-wrapper");
 
 const customOptions = {
   protocol: "https",
-  // hostName
   versionPath: "/api/v2/",
   cache: true,
-  timeout: 5 * 1000, // 5s
+  timeout: 10 * 1000, // 5s
   cacheImages: true,
 };
 
-const P = new Pokedex.Pokedex(customOptions);
+const P = new Pokedex.Pokedex(customOptions); // initialization
 
 export const fetchPokemons = async (queryParams) => {
   try {


### PR DESCRIPTION
## Changes
1. Increased timeout property in `customOptions` of wrapper.
2. Invoke `setIsLoading` in `catch` of `getMorePokemons`.

## Purpose
Prevent errors and spinner from staying up once user scrolls past 898 pokemons(due to API data gap).

## Testing Steps
Scroll all the way down on home page.

Closes #151 