### PR TITLE
fix(modal): center evolution sprites inside modal for all cases

### DIFF
--- a/src/components/EvolutionTab.js
+++ b/src/components/EvolutionTab.js
@@ -145,6 +145,7 @@ const EvolutionTab = ({ evolutionChainUrl, pokemonColor }) => {
           // custom scrollbar (firefox only)
           scrollbarColor: `${pokemonColor} rgba(235, 232, 232, 0.4)`,
           overflowX: "auto",
+
           // ** unknown solution for safari and chrome **
         }}
         className={"spriteContainer"}>

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -137,9 +137,9 @@ $modal-padding: 25px;
 .spriteContainer {
   display: flex;
   margin: 25px;
-  align-content: center;
   align-items: center;
-  justify-content: space-between;
+  justify-content: safe center;
+  overflow-wrap: inherit;
 }
 
 .evolution-sprites {
@@ -151,6 +151,7 @@ $modal-padding: 25px;
 .evolutionImg {
   width: 45px;
   height: 45px;
+  margin: 25px;
 }
 
 // moves panel
@@ -385,6 +386,7 @@ $modal-padding: 25px;
   }
 
   .spriteContainer {
+    border: 2px solid red;
     display: flex;
     flex-direction: column;
     justify-content: space-between;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Fix sprite evolution positioning, to where sprites are centered for all cases of evolution sprite numbers.

Closes #147 