### PR TITLE
Hover Indicator In Firefox

### DIFF
--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -53,6 +53,13 @@ nav {
   margin-top: 4px;
 }
 
+@-moz-document url-prefix() {
+  .nav-link {
+    margin-top: 4px;
+    padding-bottom: 20.5px;
+  }
+}
+
 .nav-link:hover {
   border-bottom: 4px solid #382e76;
   border-radius: 2px;
@@ -145,6 +152,13 @@ input[type="text"]:focus {
     transition: none;
   }
 
+  @-moz-document url-prefix() {
+    .nav-link {
+      margin-top: 4px;
+      padding-bottom: 20.5px;
+    }
+  }
+
   .searchBarContainer {
     width: 520px;
   }
@@ -163,6 +177,13 @@ input[type="text"]:focus {
 
   .nav-link {
     padding-bottom: 13px;
+  }
+
+  @-moz-document url-prefix() {
+    .nav-link {
+      margin-top: 4px;
+      padding-bottom: 13.5px;
+    }
   }
 
   .nav-icon {
@@ -231,6 +252,12 @@ input[type="text"]:focus {
 
   .nav-link {
     padding-bottom: 10px;
+  }
+
+  @-moz-document url-prefix() {
+    .nav-link {
+      padding-bottom: 9px;
+    }
   }
 
   .nav-icon {

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -386,7 +386,6 @@ $modal-padding: 25px;
   }
 
   .spriteContainer {
-    border: 2px solid red;
     display: flex;
     flex-direction: column;
     justify-content: space-between;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Fixed styling for link hover indicator in firefox browser.
2. Removed landmark styling border

## Purpose
Link hover indicator was not set correctly when using firefox.

## Approach
Using  @-moz-document url-prefix() in SCSS to target the link.

## Testing Steps
Open in firefox
Hover the All Pokemon link
Observe

## Learning
Had not used @-moz-document url-prefix() for specific styling for firefox browsers before.

Closes #155  